### PR TITLE
Move off deprecated reranker and LLM endpoints

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -17,7 +17,7 @@ summarization:
   enable: true
   method: "batch"
   llm:
-    model: nvidia/nvidia-nemotron-nano-9b-v2
+    model: nvidia/nemotron-3-nano-30b-a3b
     base_url: https://integrate.api.nvidia.com/v1
     max_tokens: 2048
     temperature: 0.2
@@ -49,7 +49,7 @@ chat:
     top_k: 25
     confidence_threshold: 0.0
   llm:
-    model: nvidia/nvidia-nemotron-nano-9b-v2
+    model: nvidia/nemotron-3-nano-30b-a3b
     base_url: https://integrate.api.nvidia.com/v1
     max_tokens: 2048
     temperature: 0.5
@@ -57,14 +57,14 @@ chat:
     model: "nvidia/llama-3.2-nv-embedqa-1b-v2"
     base_url: "http://embedding-nim:8000/v1/"
   reranker:
-    model: "nvidia/llama-3.2-nv-rerankqa-1b-v2"
-    base_url: https://ai.api.nvidia.com/v1/retrieval/nvidia/llama-3_2-nv-rerankqa-1b-v2/reranking
+    model: "nvidia/llama-nemotron-rerank-vl-1b-v2"
+    base_url: "http://reranker-nim:8000/v1"
 
 notification:
   enable: false
   endpoint: "http://127.0.0.1:60000/via-alert-callback"
   llm:
-    model: nvidia/nvidia-nemotron-nano-9b-v2
+    model: nvidia/nemotron-3-nano-30b-a3b
     base_url: https://integrate.api.nvidia.com/v1
     max_tokens: 2048
     temperature: 0.2

--- a/docker/deploy/compose.yaml
+++ b/docker/deploy/compose.yaml
@@ -38,6 +38,28 @@ services:
               device_ids: ['${EMBEDDING_GPU_ID:-0}']
               capabilities: [gpu]
 
+  # Reranking NIM. Self-hosted rather than hosted: the pinned
+  # langchain-nvidia-ai-endpoints validates rerank models against its own
+  # registry, which predates this model, and the SDK cannot be upgraded without
+  # breaking the langchain-core pin.
+  reranker-nim:
+    container_name: reranker-nim
+    image: "nvcr.io/nim/nvidia/llama-nemotron-rerank-vl-1b-v2:2.3.0"
+    volumes:
+      - ${MODEL_DIRECTORY:-.}:/opt/nim/.cache
+    ports:
+      - "8003:8000"
+    environment:
+      NGC_API_KEY: ${NVIDIA_API_KEY:?"NVIDIA_API_KEY is required"}
+    shm_size: 16gb
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              device_ids: ['${RERANKER_GPU_ID:-0}']
+              capabilities: [gpu]
+
   vss-ctx-rag-retriever:
     image: ctx_rag
     build:

--- a/src/vss_ctx_rag/aiq/utils.py
+++ b/src/vss_ctx_rag/aiq/utils.py
@@ -141,7 +141,7 @@ def create_vss_ctx_rag_config(name: str):
 
         embedding_model_name: EmbedderRef
 
-        rerank_model_name: str = "nvidia/llama-3.2-nv-rerankqa-1b-v2"
+        rerank_model_name: str = "nvidia/llama-nemotron-rerank-vl-1b-v2"
         rerank_model_url: str = "https://integrate.api.nvidia.com/v1"
         rag_type: str = "vector-rag"  # or "graph-rag"
         chat_batch_size: int = 1

--- a/src/vss_ctx_rag/aiq_config/function/config-ingestion-function.yml
+++ b/src/vss_ctx_rag/aiq_config/function/config-ingestion-function.yml
@@ -46,8 +46,8 @@ functions:
 
     embedding_model_name: embedding_llm
 
-    rerank_model_name: "nvidia/llama-3.2-nv-rerankqa-1b-v2"
-    rerank_model_url: "https://ai.api.nvidia.com/v1/retrieval/nvidia/llama-3_2-nv-rerankqa-1b-v2/reranking"
+    rerank_model_name: "nvidia/llama-nemotron-rerank-vl-1b-v2"
+    rerank_model_url: "http://reranker-nim:8000/v1"
     rag_type: "vector-rag" # or "graph-rag"
     chat_batch_size: 1
     summ_batch_size: 5

--- a/src/vss_ctx_rag/aiq_config/function/config-retrieval-function.yml
+++ b/src/vss_ctx_rag/aiq_config/function/config-retrieval-function.yml
@@ -46,8 +46,8 @@ functions:
 
     embedding_model_name: embedding_llm
 
-    rerank_model_name: "nvidia/llama-3.2-nv-rerankqa-1b-v2"
-    rerank_model_url: "https://ai.api.nvidia.com/v1/retrieval/nvidia/llama-3_2-nv-rerankqa-1b-v2/reranking"
+    rerank_model_name: "nvidia/llama-nemotron-rerank-vl-1b-v2"
+    rerank_model_url: "http://reranker-nim:8000/v1"
     rag_type: "vector-rag" # or "graph-rag"
     chat_batch_size: 1
     summ_batch_size: 5

--- a/src/vss_ctx_rag/aiq_config/workflow/config-ingestion-workflow.yml
+++ b/src/vss_ctx_rag/aiq_config/workflow/config-ingestion-workflow.yml
@@ -45,8 +45,8 @@ workflow:
 
   embedding_model_name: embedding_llm
 
-  rerank_model_name: "nvidia/llama-3.2-nv-rerankqa-1b-v2"
-  rerank_model_url: "https://ai.api.nvidia.com/v1/retrieval/nvidia/llama-3_2-nv-rerankqa-1b-v2/reranking"
+  rerank_model_name: "nvidia/llama-nemotron-rerank-vl-1b-v2"
+  rerank_model_url: "http://reranker-nim:8000/v1"
   rag_type: "vector-rag" # or "graph-rag"
   chat_batch_size: 1
   summ_batch_size: 5

--- a/src/vss_ctx_rag/aiq_config/workflow/config-retrieval-workflow.yml
+++ b/src/vss_ctx_rag/aiq_config/workflow/config-retrieval-workflow.yml
@@ -45,8 +45,8 @@ workflow:
 
   embedding_model_name: embedding_llm
 
-  rerank_model_name: "nvidia/llama-3.2-nv-rerankqa-1b-v2"
-  rerank_model_url: "https://ai.api.nvidia.com/v1/retrieval/nvidia/llama-3_2-nv-rerankqa-1b-v2/reranking"
+  rerank_model_name: "nvidia/llama-nemotron-rerank-vl-1b-v2"
+  rerank_model_url: "http://reranker-nim:8000/v1"
   rag_type: "vector-rag" # or "graph-rag"
   chat_batch_size: 1
   summ_batch_size: 5

--- a/src/vss_ctx_rag/tools/storage/milvus_db.py
+++ b/src/vss_ctx_rag/tools/storage/milvus_db.py
@@ -38,8 +38,8 @@ class MilvusDBTool(StorageTool):
         port="19530",
         embedding_model_name="nvidia/llama-3.2-nv-embedqa-1b-v2",
         embedding_base_url="https://integrate.api.nvidia.com/v1",
-        reranker_model_name="nvidia/llama-3.2-nv-rerankqa-1b-v2",
-        reranker_base_url="https://ai.api.nvidia.com/v1/retrieval/nvidia/llama-3_2-nv-rerankqa-1b-v2/reranking",
+        reranker_model_name="nvidia/llama-nemotron-rerank-vl-1b-v2",
+        reranker_base_url="http://reranker-nim:8000/v1",
         name="milvus_db",
     ) -> None:
         super().__init__(name)


### PR DESCRIPTION
Moves this branch off two deprecated inference endpoints, and validates the result on a GPU.

Builds on the work in #43, which targeted `main`. This one targets `dev/streaming-data-to-rag` directly — the branch the Streaming Data to RAG blueprint actually pins — so it can be reviewed and merged on its own. Opening it separately rather than pushing to #43 because I don't have write access to that branch.

## Why

**The reranker is already gone.** The hosted `llama-3_2-nv-rerankqa-1b-v2` endpoint this branch calls returns:

```
[410] Gone — This endpoint has reached its end of life on 2026-05-18T00:00:00Z and is no longer available.
```

So retrieval reranking fails on this branch today, not at some future date.

**The LLM is next.** `nvidia/nvidia-nemotron-nano-9b-v2` (used for chat, summarization and notification) is in the August 2026 deprecation wave. It still responds, but not for long.

## What changed

| Component | Before | After |
|---|---|---|
| Reranker | `llama-3.2-nv-rerankqa-1b-v2` @ `ai.api.nvidia.com` | `llama-nemotron-rerank-vl-1b-v2`, **self-hosted** |
| LLM (×3) | `nvidia-nemotron-nano-9b-v2` @ `integrate.api` | `nemotron-3-nano-30b-a3b` @ `integrate.api` |
| Embedding | *unchanged* | *unchanged* |
| Parakeet ASR | *unchanged* | *unchanged* |

### The reranker has to be self-hosted — this isn't a style preference

Pointing the config at the hosted successor **does not work with the pinned SDK**. `langchain-nvidia-ai-endpoints==0.3.7` validates rerank model names against its own registry:

```
Model nvidia/llama-nemotron-rerank-vl-1b-v2 is unknown, check `available_models`
```

That registry knows only four models, all previous-generation. The request is rejected client-side before it's ever sent — note the hosted endpoint itself answers `200` to a raw `curl`, so this fails *only* through the SDK.

Upgrading the SDK isn't an option either:

```
ERROR: Cannot install langchain-nvidia-ai-endpoints==0.3.19 and langchain_core==0.3.21
because these package versions have conflicting dependencies.
ERROR: ResolutionImpossible
```

So the reranker follows the pattern this branch already uses for embedding: a `reranker-nim` service in `compose.yaml` (mirroring `embedding-nim`), with `base_url` pointing at it. `RERANKER_GPU_ID` defaults to `0` alongside `EMBEDDING_GPU_ID`; set them apart on multi-GPU hosts.

The LLM needed no such treatment — `ChatNVIDIA` passes model names straight through with no registry check. I verified that against the pinned SDK rather than assuming it, since the two clients behave differently.

### Stale defaults in source

`milvus_db.py` and `aiq/utils.py` still hardcode the dead reranker as their default. `config.yaml` overrides them at runtime, so nothing is broken today — but they're the values a new call site inherits, so they're updated too.

### What is deliberately *not* changed

**Embedding** and the **Parakeet ASR NIM** are both self-hosted containers on this branch. Hosted-endpoint deprecation doesn't apply to them, so they're left alone.

This is worth stating explicitly: Parakeet has been flagged as needing replacement in the deprecation tracking, and on this branch that flag is a false positive — it runs from `nvcr.io`, not `build.nvidia.com`. No action needed for it here.

## Validation

Run on a single L4. The reranker NIM (`llama-nemotron-rerank-vl-1b-v2:2.3.0`) came up healthy and advertises the model id the config asks for:

```
GET /v1/models → ["nvidia/llama-nemotron-rerank-vl-1b-v2"]
```

Then the **pinned** SDK (`langchain-nvidia-ai-endpoints==0.3.7`, `langchain_core==0.3.21`) reranking through it, query *"what was said about GPUs?"*:

```
1.  -5.4147   GPU acceleration for radio signal processing
2.  -7.4962   weather clear skies wind ten knots
3.  -7.9099   banana bread recipe with walnuts
```

Correct ordering with a clear margin — so the client accepts the model, reaches the NIM, and gets meaningful scores. That's the specific thing that fails against the hosted endpoint.

LLM: `nemotron-3-nano-30b-a3b` verified responding through `ChatNVIDIA` on the pinned SDK.

## Worth flagging

- **`nemotron-3-nano-30b-a3b` has a limited shelf life.** Nemotron-3.5-Nano goes live 2026-08-11, and the 3-Nano generation is expected to retire roughly two weeks after. This change gets the branch off a model that's deprecating now, but another LLM bump is likely soon. Happy to follow up once 3.5-Nano is available.
- **A longer-term option**, if you'd prefer to stop tracking hosted-endpoint churn: the same self-hosting treatment applied to the reranker here works for the LLM too. Entirely your call — this PR keeps the LLM hosted to stay close to the existing shape.
- **Not run end to end**: I validated the reranker path and the LLM endpoint, not a full Streaming Data to RAG pipeline run with SDR ingest.
