### PR TITLE
Update deprecating LLM nemotron-3-nano-30b-a3b → nemotron-3.5-lightning-30b-a3b (+
  thinking:false for strict-JSON)

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -17,8 +17,11 @@ summarization:
   enable: true
   method: "batch"
   llm:
-    model: nvidia/nemotron-3-nano-30b-a3b
+    model: nvidia/nemotron-3.5-lightning-30b-a3b
     base_url: https://integrate.api.nvidia.com/v1
+    extra_body:
+      chat_template_kwargs:
+        thinking: false
     max_tokens: 2048
     temperature: 0.2
     top_p: 0.7
@@ -49,8 +52,11 @@ chat:
     top_k: 25
     confidence_threshold: 0.0
   llm:
-    model: nvidia/nemotron-3-nano-30b-a3b
+    model: nvidia/nemotron-3.5-lightning-30b-a3b
     base_url: https://integrate.api.nvidia.com/v1
+    extra_body:
+      chat_template_kwargs:
+        thinking: false
     max_tokens: 2048
     temperature: 0.5
   embedding:
@@ -64,8 +70,11 @@ notification:
   enable: false
   endpoint: "http://127.0.0.1:60000/via-alert-callback"
   llm:
-    model: nvidia/nemotron-3-nano-30b-a3b
+    model: nvidia/nemotron-3.5-lightning-30b-a3b
     base_url: https://integrate.api.nvidia.com/v1
+    extra_body:
+      chat_template_kwargs:
+        thinking: false
     max_tokens: 2048
     temperature: 0.2
     top_p: 0.7


### PR DESCRIPTION
## What & why

`nvidia/nemotron-3-nano-30b-a3b` — the hosted LLM used by the summarization, chat, and notification paths in `config/config.yaml` — is being deprecated as a hosted endpoint. This updates all three references to its successor **`nvidia/nemotron-3.5-lightning-30b-a3b`**, which the hosted gateway currently serves (verified live: `/v1/models` lists it and a completion returns HTTP 200 echoing the model id). No self-hosted container is needed.

## The non-obvious part: disable "thinking"

`nemotron-3.5-lightning` is a reasoning model — on long / agentic / RAG prompts it emits chain-of-thought into the response `content`. With this blueprint's strict-JSON contract and `max_tokens: 2048`, that overflows the budget, the JSON is truncated → parse failure → the pipeline falls back to a canned "cannot answer," and graph-extraction during ingest fails intermittently.

Fix: `extra_body.chat_template_kwargs.thinking: false` on each LLM block. With it, `content` is clean JSON and reasoning is separated (`reasoning_content: null`); verified empirically against the endpoint. This resolved both the probe failure and the ingest-side graph-extraction failures.

## Validated on real hardware

Deployed the full blueprint on an NVIDIA L4 (23 GB) — 14 containers (ASR + embedding + reranker NIMs + the graph-RAG stack) — ingested live FM-radio transcripts, then ran the graph-RAG probe:

- **Probe passes:** a grounded answer citing `fm-radio-ch0` / `ch2` with timestamps from the run; 3 clean JSON parses, 0 failures.
- **Negative control** (a topic never discussed) correctly refuses — confirming the answer was genuinely retrieval-grounded, not confabulated.
- After the fix: 26 docs ingested, 23 graphs, **0 extraction failures, 0 thinking-process leaks**. Reproducible across repeated probes.

## Notes for maintainers

- Config is baked into the `ctx_rag` image (`COPY config/`), so this needs an **image rebuild** to take effect — editing config alone silently keeps the old model.
- `max_tokens: 2048` is a little tight for a reasoning model even with thinking off (one truncated-JSON retry self-recovered) — worth raising for headroom.

---
Prepared and validated by an automated blueprint-refresh CI (deploy → swap → re-validate on a GPU). Please review before merging.
